### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/user/views.py
+++ b/user/views.py
@@ -5,6 +5,7 @@ from django.contrib import messages
 from django.contrib.auth.models import User
 from user.models import Profile, Message
 from django.http import HttpRequest, HttpResponseRedirect, HttpResponse
+from django.utils.http import url_has_allowed_host_and_scheme
 from user.forms import CustomUserCreationForm, ProfileForm, MessageForm
 from common.utils import get_admin_profile_id
 
@@ -20,9 +21,10 @@ def login_user(request: HttpRequest) -> HttpResponseRedirect|HttpResponse:
         user = authenticate(request, username=username, password=password)
         if user is not None:
             login(request, user)
-            return redirect(
-                request.GET['next'] if 'next' in request.GET else 'account'
-            )
+            next_url = request.GET['next'] if 'next' in request.GET else 'account'
+            if not url_has_allowed_host_and_scheme(next_url, allowed_hosts=request.get_host()):
+                next_url = 'account'
+            return redirect(next_url)
         else:
             messages.error(request, 'Неверное имя пользователя или пароль')
     return render(request, 'users/login_register.html')


### PR DESCRIPTION
Potential fix for [https://github.com/Pavel14701/foltz/security/code-scanning/1](https://github.com/Pavel14701/foltz/security/code-scanning/1)

To fix the issue, we need to validate the `next` parameter before using it in the redirect. The best approach in Django is to use the `url_has_allowed_host_and_scheme` utility function, which ensures that the URL is safe and belongs to an allowed host. If the `next` parameter is not valid, we should redirect to a safe default location, such as `'account'`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Обзор от Sourcery

Исправлена уязвимость открытого редиректа в представлении входа в систему.

Исправления ошибок:
- Проверка URL-адреса перенаправления `next` после входа в систему, чтобы убедиться, что он принадлежит текущему хосту.
- Перенаправление на страницу 'account' по умолчанию, если URL-адрес `next` недействителен или указывает на внешний сайт.

<details>
<summary>Original summary in English</summary>

## Краткое описание от Sourcery

Исправлена уязвимость открытого редиректа в представлении входа в систему путем проверки параметра URL `next` перед перенаправлением.

Исправления ошибок:
- Проверка параметра URL `next` после входа в систему, чтобы убедиться, что он указывает на разрешенный хост и схему.
- Перенаправление на страницу 'account' по умолчанию, если параметр `next` недействителен или указывает на внешний сайт.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix an open redirect vulnerability in the login view by validating the `next` URL parameter before redirection.

Bug Fixes:
- Validate the `next` URL parameter after login to ensure it points to an allowed host and scheme.
- Redirect to the 'account' page by default if the `next` parameter is invalid or points to an external site.

</details>

</details>